### PR TITLE
change USB vendor string to tinysa.org, add USB product string for Ultra

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,13 @@ endif
 # Build global options
 ##############################################################################
 
+# format va.b-n-gxxxxxxx
+# or     va.b-nn-gxxxxxxx
+# or     va.b-nnn-gxxxxxxx
+# or     ...
+
 ifeq ($(VERSION),)
-  VERSION="$(PROJECT)_$(shell git describe --tags)"
+  VERSION="$(PROJECT)_$(shell git describe --tags --long)"
 endif
 
 ##############################################################################
@@ -297,15 +302,19 @@ clean:
 	rm -f -rf build/tinySA4.* build/lst/*.* build/obj/*.*
 else
 clean:
-	rm -f -rf build/tinySA.*
+	rm -f -rf build/$(PROJECT).*
 endif
 
-flash: build/ch.bin
-	dfu-util -d 0483:df11 -a 0 -s 0x08000000:leave -D build/ch.bin
+flash: build/$(PROJECT).bin
+	-@printf "reset dfu\r" >/dev/cu.usbmodem401 # mac
+	-@printf "reset dfu\r" >/dev/ttyACM0 # linux
+	sleep 2
+	dfu-util -d 0483:df11 -a 0 -s 0x08000000:leave -D $<
 
-dfu:
-	c:/work/dfu/HEX2DFU build/ch.hex build/ch.dfu
-	-@printf "reset dfu\r" >/dev/cu.usbmodem401
+dfu:	build/$(PROJECT).hex
+	-@#c:/work/dfu/HEX2DFU $< build/$(PROJECT).dfu # win
+	-@hex2dfu -i $< -o build/$(PROJECT).dfu # mac / linux
+
 
 TAGS: Makefile
 ifeq ($(TARGET),F303)

--- a/ui_sa.c
+++ b/ui_sa.c
@@ -4386,13 +4386,23 @@ redraw_cal_status:
 
   // Version
   y += YSTEP + YSTEP/2 ;
-#ifdef TINYSA4
-  strncpy(buf,&TINYSA_VERSION[9], BLEN+1);
-#else
-  strncpy(buf,&TINYSA_VERSION[8], BLEN+1);
+#ifdef TINYSA4 // 'tinySA4_v1.2-[0-9]*-gxxxxxxx'
+  strncpy(buf,&TINYSA_VERSION[9], BLEN+1); // '1.2-...'
+#else // 'tinySA_v1.2-[0-9]*-gxxxxxxx'
+  strncpy(buf,&TINYSA_VERSION[8], BLEN+1); // '1.2-...'
 #endif
-  if (buf[7]=='-') {
-    buf[3] = buf[4];
+  if (buf[5]=='-' ) { // '1.2-n-g...'
+    if (buf[4]=='0')  // '1.2-0-g...'
+      buf[3] = 0;  // -> '1.2'
+    else {
+      buf[5] = buf[4]; // -> '1.200n'
+      buf[4] = '0';
+      buf[3] = '0';
+    }
+  } else if (buf[6]=='-' ) { // 1.2-nn-g...
+    buf[3] = '0'; // -> '1.20nn'
+  } else { // 1.2-345-g... (or 1.2-3456...)
+    buf[3] = buf[4]; // -> '1.2345'
     buf[4] = buf[5];
     buf[5] = buf[6];
   }

--- a/usbcfg.c
+++ b/usbcfg.c
@@ -178,10 +178,11 @@ static const uint8_t vcom_string2[] = {
 #ifdef TINYSA4
 /*
  * Serial Number string. VERSION = 'tinySA4_v1.3-nnn-gxxxxxxx'
- *                                  0123456789012345678901234
+ *                                  01234567890123456789012
+ * skip last two 'xx' char due to  'tinySA4_v1.3-n-gxxxxxxx'
  */
 static const uint8_t vcom_string3[] = {
-  USB_DESC_BYTE(36),                    /* bLength.                         */
+  USB_DESC_BYTE(32),                    /* bLength.                         */
   USB_DESC_BYTE(USB_DESCRIPTOR_STRING), /* bDescriptorType.                 */
   VERSION[8], 0,  /* 'v' */
   VERSION[9], 0,  /* '1' */
@@ -198,16 +199,15 @@ static const uint8_t vcom_string3[] = {
   VERSION[20], 0, /* 'x' */
   VERSION[21], 0, /* 'x' */
   VERSION[22], 0, /* 'x' */
-  VERSION[23], 0, /* 'x' */
-  VERSION[24], 0  /* 'x' */
 };
 #else
 /*
  * Serial Number string. VERSION = 'tinySA_v1.3-nnn-gxxxxxxx'
- *                                  012345678901234567890123
+ *                                  0123456789012345678901
+ * skip last two 'xx' char due to  'tinySA_v1.3-n-gxxxxxxx'
  */
 static const uint8_t vcom_string3[] = {
-  USB_DESC_BYTE(36),                    /* bLength.                         */
+  USB_DESC_BYTE(32),                    /* bLength.                         */
   USB_DESC_BYTE(USB_DESCRIPTOR_STRING), /* bDescriptorType.                 */
   VERSION[7], 0,  /* 'v' */
   VERSION[8], 0,  /* '1' */
@@ -224,8 +224,6 @@ static const uint8_t vcom_string3[] = {
   VERSION[19], 0, /* 'x' */
   VERSION[20], 0, /* 'x' */
   VERSION[21], 0, /* 'x' */
-  VERSION[22], 0, /* 'x' */
-  VERSION[23], 0  /* 'x' */
 };
 #endif
 

--- a/usbcfg.c
+++ b/usbcfg.c
@@ -150,21 +150,31 @@ static const uint8_t vcom_string0[] = {
  * Vendor string.
  */
 static const uint8_t vcom_string1[] = {
-  USB_DESC_BYTE(38),                    /* bLength.                         */
+  USB_DESC_BYTE(22),                    /* bLength.                         */
   USB_DESC_BYTE(USB_DESCRIPTOR_STRING), /* bDescriptorType.                 */
-  'S', 0, 'T', 0, 'M', 0, 'i', 0, 'c', 0, 'r', 0, 'o', 0, 'e', 0,
-  'l', 0, 'e', 0, 'c', 0, 't', 0, 'r', 0, 'o', 0, 'n', 0, 'i', 0,
-  'c', 0, 's', 0
+  't', 0, 'i', 0, 'n', 0, 'y', 0, 's', 0, 'a', 0, '.', 0, 'o', 0, 'r', 0, 'g', 0
 };
 
+#ifdef TINYSA4
 /*
- * Device Description string, use the real name of the device.
+ * Device Description string, use "tinySA Ultra"
+ */
+static const uint8_t vcom_string2[] = {
+  USB_DESC_BYTE(26),                    /* bLength.                         */
+  USB_DESC_BYTE(USB_DESCRIPTOR_STRING), /* bDescriptorType.                 */
+  't', 0, 'i', 0, 'n', 0, 'y', 0, 'S', 0, 'A', 0,
+  ' ', 0, 'U', 0, 'l', 0, 't', 0, 'r', 0, 'a', 0
+};
+#else
+/*
+ * Device Description string, use "tinySA"
  */
 static const uint8_t vcom_string2[] = {
   USB_DESC_BYTE(14),                    /* bLength.                         */
   USB_DESC_BYTE(USB_DESCRIPTOR_STRING), /* bDescriptorType.                 */
   't', 0, 'i', 0, 'n', 0, 'y', 0, 'S', 0, 'A', 0
 };
+#endif
 
 /*
  * Serial Number string. TODO: use real product version.

--- a/usbcfg.c
+++ b/usbcfg.c
@@ -157,13 +157,12 @@ static const uint8_t vcom_string1[] = {
 
 #ifdef TINYSA4
 /*
- * Device Description string, use "tinySA Ultra"
+ * Device Description string, use "tinySA4" as in "VERSION"
  */
 static const uint8_t vcom_string2[] = {
-  USB_DESC_BYTE(26),                    /* bLength.                         */
+  USB_DESC_BYTE(16),                    /* bLength.                         */
   USB_DESC_BYTE(USB_DESCRIPTOR_STRING), /* bDescriptorType.                 */
-  't', 0, 'i', 0, 'n', 0, 'y', 0, 'S', 0, 'A', 0,
-  ' ', 0, 'U', 0, 'l', 0, 't', 0, 'r', 0, 'a', 0
+  't', 0, 'i', 0, 'n', 0, 'y', 0, 'S', 0, 'A', 0, '4', 0
 };
 #else
 /*
@@ -176,16 +175,59 @@ static const uint8_t vcom_string2[] = {
 };
 #endif
 
+#ifdef TINYSA4
 /*
- * Serial Number string. TODO: use real product version.
+ * Serial Number string. VERSION = 'tinySA4_v1.3-nnn-gxxxxxxx'
+ *                                  0123456789012345678901234
  */
 static const uint8_t vcom_string3[] = {
-  USB_DESC_BYTE(8),                     /* bLength.                         */
+  USB_DESC_BYTE(36),                    /* bLength.                         */
   USB_DESC_BYTE(USB_DESCRIPTOR_STRING), /* bDescriptorType.                 */
-  '0' + CH_KERNEL_MAJOR, 0,
-  '0' + CH_KERNEL_MINOR, 0,
-  '0' + CH_KERNEL_PATCH, 0
+  VERSION[8], 0,  /* 'v' */
+  VERSION[9], 0,  /* '1' */
+  VERSION[10], 0, /* '.' */
+  VERSION[11], 0, /* '3' */
+  VERSION[12], 0, /* '-' */
+  VERSION[13], 0, /* 'n' */
+  VERSION[14], 0, /* 'n' */
+  VERSION[15], 0, /* 'n' */
+  VERSION[16], 0, /* '-' */
+  VERSION[17], 0, /* 'g' */
+  VERSION[18], 0, /* 'x' */
+  VERSION[19], 0, /* 'x' */
+  VERSION[20], 0, /* 'x' */
+  VERSION[21], 0, /* 'x' */
+  VERSION[22], 0, /* 'x' */
+  VERSION[23], 0, /* 'x' */
+  VERSION[24], 0  /* 'x' */
 };
+#else
+/*
+ * Serial Number string. VERSION = 'tinySA_v1.3-nnn-gxxxxxxx'
+ *                                  012345678901234567890123
+ */
+static const uint8_t vcom_string3[] = {
+  USB_DESC_BYTE(36),                    /* bLength.                         */
+  USB_DESC_BYTE(USB_DESCRIPTOR_STRING), /* bDescriptorType.                 */
+  VERSION[7], 0,  /* 'v' */
+  VERSION[8], 0,  /* '1' */
+  VERSION[9], 0,  /* '.' */
+  VERSION[10], 0, /* '3' */
+  VERSION[11], 0, /* '-' */
+  VERSION[12], 0, /* 'n' */
+  VERSION[13], 0, /* 'n' */
+  VERSION[14], 0, /* 'n' */
+  VERSION[15], 0, /* '-' */
+  VERSION[16], 0, /* 'g' */
+  VERSION[17], 0, /* 'x' */
+  VERSION[18], 0, /* 'x' */
+  VERSION[19], 0, /* 'x' */
+  VERSION[20], 0, /* 'x' */
+  VERSION[21], 0, /* 'x' */
+  VERSION[22], 0, /* 'x' */
+  VERSION[23], 0  /* 'x' */
+};
+#endif
 
 /*
  * Strings wrappers array.


### PR DESCRIPTION
One minor addition to my previous PR:
Replace vendor string "STMicroelectronics" from demo code with "tinysa.org"
Use either "tinySA" or "tinySA Ultra" as product string depending on "#ifdef TINYSA4"

Signed-off-by: Martin <Ho-Ro@users.noreply.github.com>

EDIT: added a 2nd commit that displays the FW version as USB product sernum string, changed the USB product string for Ultra to "tinySA4" as also defined in Makefile and full FW version string, see dmesg log:

[  +1,567891] usb 1-1: new full-speed USB device number 121 using uhci_hcd
[  +0,179094] usb 1-1: New USB device found, idVendor=0483, idProduct=5740, bcdDevice= 2.00
[  +0,000008] usb 1-1: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[  +0,000005] usb 1-1: Product: tinySA
[  +0,000005] usb 1-1: Manufacturer: tinysa.org
[  +0,000004] usb 1-1: SerialNumber: v1.3-498-gf04006f
[  +0,003544] cdc_acm 1-1:1.0: ttyACM0: USB ACM device
