### PR TITLE
Fix make 510

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,23 @@
 # NOTE: Can be overridden externally.
 #
 
-#Build target
-ifeq ($(TARGET),)
-  TARGET = F072
-else
-  TARGET = F303
+# Build target, define with e.g. "TARGET=F303 make"
+# If no TARGET defined use one of these two:
+#  F072 (tinySA aka. TINYSA3 aka. TINYSA_F072)
+#  F303 (tinySA Ultra aka. TINYSA4 aka. TINYSA_F303)
+DEFAULT_TARGET = F072
+
+# target specified?
+ifdef TARGET # must be one of F072 or F303
+ ifneq ($(TARGET),F072)
+  ifneq ($(TARGET),F303)
+   # set default if none of these
+   TARGET = $(DEFAULT_TARGET)
+  endif
+ endif
+else # no target specified
+ # set default one
+ TARGET = $(DEFAULT_TARGET)
 endif
 
 # Compiler options here.
@@ -296,14 +308,8 @@ RULESPATH = $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC
 include $(RULESPATH)/rules.mk
 #include $(CHIBIOS)/memory.mk
 
-
-ifeq ($(TARGET),F303)
-clean:
-	rm -f -rf build/tinySA4.* build/lst/*.* build/obj/*.*
-else
 clean:
 	rm -f -rf build/$(PROJECT).* build/lst/*.* build/obj/*.*
-endif
 
 flash: build/$(PROJECT).bin
 	-@printf "reset dfu\r" >/dev/cu.usbmodem401 # mac

--- a/nanovna.h
+++ b/nanovna.h
@@ -18,7 +18,7 @@
  */
 #include "ch.h"
 
-//#ifdef TINYSA_F303
+#ifdef TINYSA_F303
 #ifdef TINYSA_F072
 #error "Remove comment for #ifdef TINYSA_F303"
 #endif
@@ -26,7 +26,7 @@
 #define TINYSA4
 #endif
 #define TINYSA4_PROTO
-//#endif
+#endif
 
 #ifdef TINYSA_F072
 #ifdef TINYSA_F303


### PR DESCRIPTION
It is not possible to build the tinySA version with the latest commits:
```
LANG=C make            
Makefile:305: warning: overriding recipe for target 'clean'
ChibiOS/os/common/startup/ARMCMx/compilers/GCC/rules.mk:301: warning: ignoring old recipe for target 'clean'
Compiling crt0_v6m.s
...
Compiling adc.c
In file included from ./NANOVNA_STM32_F072/adc.c:22:
./nanovna.h:23:2: error: #error "Remove comment for #ifdef TINYSA_F303"
 #error "Remove comment for #ifdef TINYSA_F303"
  ^~~~~
./nanovna.h:132: warning: "VARIANT" redefined
 #define VARIANT(X,Y) (Y)
 
./nanovna.h:118: note: this is the location of the previous definition
 #define VARIANT(X,Y) (X)
...
./nanovna.h:210:19: error: conflicting types for 'freq_t'
  typedef uint64_t freq_t;
                   ^~~~~~
./nanovna.h:201:18: note: previous declaration of 'freq_t' was here
 typedef uint32_t freq_t;
                  ^~~~~~
./nanovna.h:211:18: error: conflicting types for 'long_t'
  typedef int64_t long_t;
                  ^~~~~~
./nanovna.h:202:18: note: previous declaration of 'long_t' was here
  typedef int32_t long_t;
                  ^~~~~~
```

[the recent change](https://github.com/erikkaashoek/tinySA/commit/b9b9ea120c33906df70d4ff231e9efab77398c6d#diff-95ce5fa93f025d6fe08502c9d420ca81190722b0284709cc5ba9e9c87750b5db) defines for a `TINYSA_F072` build also `TINYSA4` (additional to the already defined `TINYSA3`) what leads to the re-definitions and in the end to compile errors:

``` 
#ifdef TINYSA3
#define VARIANT(X,Y) (X)
#define DEFAULT_IF  433800000
#define DEFAULT_SPUR_IF 434000000
...
#endif
#ifdef TINYSA4
#define FREQ_MULTIPLIER 100         // Multiplier of the 30MHz reference to get accurate frequency correction
#define VARIANT(X,Y) (Y)
#define DEFAULT_IF  ((freq_t)977400000)
#define DEFAULT_SPUR_OFFSET ((freq_t)(actual_rbw_x10 > 3000 ? 1500000 : 1000000))
...
#endif
...
#ifdef TINYSA3
typedef uint32_t freq_t;
 typedef int32_t long_t;
...
#endif
#ifdef TINYSA4
 typedef uint64_t freq_t;
 typedef int64_t long_t;
...
#endif
```

My change allows to build both versions:
- `TARGET=F072 make` builds `tinySA.*`
- `TARGET=F303 make` builds `tinySA4.*`
all other values of TARGET build the default target F072, but you can change this if you want F303 as default.
