### PR TITLE
fix https://github.com/erikkaashoek/tinySA/issues/50

### DIFF
--- a/ui.c
+++ b/ui.c
@@ -3895,9 +3895,11 @@ static const menuitem_t menu_limit_modify[] =
 
 static const menuitem_t menu_limit_select[] = {
   { MT_ADV_CALLBACK | MT_REPEATS,   DATA_STARTS_REPEATS(0,LIMITS_MAX), MT_CUSTOM_LABEL, menu_limit_select_acb },
+#ifdef __USE_SD_CARD__
   { MT_CALLBACK,    FMT_TBL_FILE,  "TABLE"S_RARROW"\nSD",     menu_sdcard_cb},
 #ifdef __SD_FILE_BROWSER__
   { MT_CALLBACK, FMT_TBL_FILE, "SD"S_RARROW"\nTABLE",            menu_sdcard_browse_cb },
+#endif
 #endif
   { MT_NONE, 0, NULL, menu_back} // next-> menu_back
 };


### PR DESCRIPTION
`make` stops with this error:

```c
Compiling ui.c
ui.c:3898:21: error: 'FMT_TBL_FILE' undeclared here (not in a function); did you mean 'MT_TITLE'?
   { MT_CALLBACK,    FMT_TBL_FILE,  "TABLE"S_RARROW"\nSD",     menu_sdcard_cb},
                     ^~~~~~~~~~~~
                     MT_TITLE
ui.c:3898:63: error: 'menu_sdcard_cb' undeclared here (not in a function); did you mean 'menu_scale_cb'?
   { MT_CALLBACK,    FMT_TBL_FILE,  "TABLE"S_RARROW"\nSD",     menu_sdcard_cb},
                                                               ^~~~~~~~~~~~~~
                                                               menu_scale_cb
ui.c:3898:3: warning: missing initializer for field 'reference' of 'menuitem_t' {aka 'const struct <anonymous>'} [-Wmissing-field-initializers]
   { MT_CALLBACK,    FMT_TBL_FILE,  "TABLE"S_RARROW"\nSD",     menu_sdcard_cb},
   ^
In file included from ui.c:24:
nanovna.h:1448:15: note: 'reference' declared here
   const void *reference;
               ^~~~~~~~~
```

caused by this function:
```c
static const menuitem_t menu_limit_select[] = {
  { MT_ADV_CALLBACK | MT_REPEATS,   DATA_STARTS_REPEATS(0,LIMITS_MAX), MT_CUSTOM_LABEL, menu_limit_select_acb },
  { MT_CA   LLBACK,    FMT_TBL_FILE,  "TABLE"S_RARROW"\nSD",     menu_sdcard_cb},
#ifdef __SD_FILE_BROWSER__
  { MT_CALLBACK, FMT_TBL_FILE, "SD"S_RARROW"\nTABLE",            menu_sdcard_browse_cb },
#endif
  { MT_NONE, 0, NULL, menu_back} // next-> menu_back
};
```
