### PR TITLE
fix tinySA build for 1.4090

### DIFF
--- a/plot.c
+++ b/plot.c
@@ -588,9 +588,9 @@ static uint16_t get_trigger_level(
 #endif
     ){
   index_y_t trigger;
+#ifdef __BANDS__
   if (setting.trigger_trace != 255)
     setting.trigger_level = measured[setting.trigger_trace][x];
-#ifdef __BANDS__
   else if (setting.multi_band && !setting.multi_trace) {
     int b = getBand(x);
     setting.trigger_level = setting.bands[b].level;


### PR DESCRIPTION
tinySA3 build is broken after latest commits:

```
Compiling plot.c
plot.c: In function 'get_trigger_level':
plot.c:591:15: error: 'setting_t' {aka 'struct setting'} has no member named 'trigger_trace'; did you mean 'trigger_mode'?
   if (setting.trigger_trace != 255)
               ^~~~~~~~~~~~~
               trigger_mode
plot.c:592:46: error: 'setting_t' {aka 'struct setting'} has no member named 'trigger_trace'; did you mean 'trigger_mode'?
     setting.trigger_level = measured[setting.trigger_trace][x];
                                              ^~~~~~~~~~~~~
                                              trigger_mode
plot.c:592:61: error: 'x' undeclared (first use in this function)
     setting.trigger_level = measured[setting.trigger_trace][x];
                                                             ^
plot.c:592:61: note: each undeclared identifier is reported only once for each function it appears in
make: *** [ChibiOS/os/common/startup/ARMCMx/compilers/GCC/rules.mk:216: build/obj/plot.o] Error 1
```
