### PR TITLE
Warning Fix: fabs() to cast abs()

### DIFF
--- a/sa_core.c
+++ b/sa_core.c
@@ -2852,7 +2852,7 @@ void interpolate_maximum(int m)
     const INTER_TYPE y1         = ref_marker_levels[idx - 1];
     const INTER_TYPE y2         = ref_marker_levels[idx + 0];
     const INTER_TYPE y3         = ref_marker_levels[idx + 1];
-    const INTER_TYPE d          = fabs(delta_Hz) * 0.5 * (y1 - y3) / ((y1 - (2 * y2) + y3) + 1e-12);
+    const INTER_TYPE d          = (INTER_TYPE)abs(delta_Hz) * 0.5 * (y1 - y3) / ((y1 - (2 * y2) + y3) + 1e-12);
     //const float bin      = (float)idx + d;
     markers[m].frequency   += d;
   }


### PR DESCRIPTION
Beste Erik, While compiling the tinySA source code I saw an opportunity to fix a warning and optimize part of the code.  This small fix saves about 3% of memory on the device.