### PR TITLE
Fix graphs and waterfall redrawing

### DIFF
--- a/nanovna.h
+++ b/nanovna.h
@@ -614,7 +614,7 @@ extern uint16_t graph_bottom;
 //
 #define CELLOFFSETX 0
 #define AREA_WIDTH_NORMAL  (CELLOFFSETX + WIDTH)
-#define AREA_HEIGHT_NORMAL (              HEIGHT + 1)
+#define AREA_HEIGHT_NORMAL (              HEIGHT)
 
 #define GRID_X_TEXT       (AREA_WIDTH_NORMAL - 7*5)
 

--- a/nanovna.h
+++ b/nanovna.h
@@ -604,7 +604,7 @@ extern uint16_t graph_bottom;
 #define SD_CARD_START   (LCD_HEIGHT-40-20)
 #define BATTERY_START   (LCD_HEIGHT-40)
 
-#define WIDTH  (LCD_WIDTH - 1 - OFFSETX)
+#define WIDTH  (LCD_WIDTH - OFFSETX)
 #define HEIGHT (GRIDY*NGRIDY)
 
 #define FREQUENCIES_XPOS1 OFFSETX
@@ -613,7 +613,7 @@ extern uint16_t graph_bottom;
 
 //
 #define CELLOFFSETX 0
-#define AREA_WIDTH_NORMAL  (CELLOFFSETX + WIDTH  + 1)
+#define AREA_WIDTH_NORMAL  (CELLOFFSETX + WIDTH)
 #define AREA_HEIGHT_NORMAL (              HEIGHT + 1)
 
 #define GRID_X_TEXT       (AREA_WIDTH_NORMAL - 7*5)

--- a/plot.c
+++ b/plot.c
@@ -2117,7 +2117,7 @@ static void update_waterfall(void){
   int i;
   int w_width = area_width < WIDTH ? area_width : WIDTH;
 //  START_PROFILE;
-  for (i = CHART_BOTTOM-1; i >=graph_bottom+1; i--) {		// Scroll down
+  for (i = CHART_BOTTOM-1; i >=graph_bottom; i--) {		// Scroll down
     ili9341_read_memory(OFFSETX, i, w_width, 1, spi_buffer);
     ili9341_bulk(OFFSETX, i+1, w_width, 1);
   }
@@ -2188,7 +2188,7 @@ static void update_waterfall(void){
       spi_buffer[j++] = color;
     }
   }
-  ili9341_bulk(OFFSETX, graph_bottom+1, w_width, 1);
+  ili9341_bulk(OFFSETX, graph_bottom, w_width, 1);
 //  STOP_PROFILE;
 }
 #if 0

--- a/plot.c
+++ b/plot.c
@@ -2117,7 +2117,12 @@ static void update_waterfall(void){
   int i;
   int w_width = area_width < WIDTH ? area_width : WIDTH;
 //  START_PROFILE;
-  for (i = CHART_BOTTOM-1; i >=graph_bottom; i--) {		// Scroll down
+#define WATERFALL_MULTI (SPI_BUFFER_SIZE / WIDTH)
+  for (i = CHART_BOTTOM-WATERFALL_MULTI; i>=graph_bottom; i-=WATERFALL_MULTI) {		// Scroll down WATERFALL_MULTI lines at once
+    ili9341_read_memory(OFFSETX, i, w_width, WATERFALL_MULTI, spi_buffer);
+    ili9341_bulk(OFFSETX, i+1, w_width, WATERFALL_MULTI);
+  }
+  for (i = CHART_BOTTOM-((CHART_BOTTOM-graph_bottom)/WATERFALL_MULTI)*WATERFALL_MULTI-1; i>=graph_bottom; i--) {  // Scroll down remaining lines
     ili9341_read_memory(OFFSETX, i, w_width, 1, spi_buffer);
     ili9341_bulk(OFFSETX, i+1, w_width, 1);
   }


### PR DESCRIPTION
This little patch improve screen redrawing by eliminating artefacts left on on the screen right-most column after making screenshot and not repainted line between graphs and waterfall.