### PR TITLE
Reduce maixmum waterfall_palette y value by 1

### DIFF
--- a/plot.c
+++ b/plot.c
@@ -2151,7 +2151,7 @@ static void update_waterfall(void){
   for (i=0; i< sweep_points; i++) {			// Add new topline
     uint16_t color;
 #ifdef _USE_WATERFALL_PALETTE
-    uint16_t y = _PALETTE_ALIGN(256 - graph_bottom + index[i]); // should be always in range 0 - graph_bottom
+    uint16_t y = _PALETTE_ALIGN(255 - graph_bottom + index[i]); // should be always in range 0 - graph_bottom
 //    y = (uint8_t)i;  // for test
     if (y > 255)            // at start the index_y_t table could be empty leading to negative y
       break;


### PR DESCRIPTION
- otherwise maximum expected value for y will trigger break in https://github.com/erikkaashoek/tinySA/blob/ed1dfed942868e9b4e21081886731bf8cdeffe89/plot.c#L2156-L2157
- should fix #102
