### PR TITLE
Fix commands exception when __USE_SERIAL_CONSOLE__ disabled

### DIFF
--- a/main.c
+++ b/main.c
@@ -2660,6 +2660,10 @@ static bool shell_check_connect(void){
 // Init shell I/O connection over USB
 static void shell_init_connection(void){
 /*
+ * Init shell thread object (need for switch threads)
+ */
+  osalThreadQueueObjectInit(&shell_thread);
+/*
  * Initializes and start serial-over-USB CDC driver SDU1, connected to USBD1
  */
   sduObjectInit(&SDU1);


### PR DESCRIPTION
the VNAShellCommand with CMD_WAIT_MUTEX flag executes an exception when __USE_SERIAL_CONSOLE__ disabled