### PR TITLE
Fix double print of the shell prompt

### DIFF
--- a/main.c
+++ b/main.c
@@ -264,10 +264,13 @@ static THD_FUNCTION(Thread1, arg)
       do {
         shell_function(shell_nargs - 1, &shell_args[1]);
         shell_function = 0;
+#ifndef VNA_SHELL_THREAD
         if (operation_requested == OP_NONE) // Don't prompt if aborted
           shell_printf(VNA_SHELL_PROMPT_STR);
+#else
         // Resume shell thread
         if (!abort_enabled) osalThreadDequeueNextI(&shell_thread, MSG_OK);
+#endif
       } while (shell_function);
       if (dirty) {
         if (MODE_OUTPUT(setting.mode))
@@ -2789,7 +2792,9 @@ static void VNAShell_executeLine(char *line)
     } else {
       operation_requested = false; // otherwise commands  will be aborted
       scp->sc_function(shell_nargs - 1, &shell_args[1]);
+#ifndef VNA_SHELL_THREAD
       shell_printf(VNA_SHELL_PROMPT_STR);
+#endif
       if (dirty) {
         operation_requested = true;   // ensure output is updated
         if (MODE_OUTPUT(setting.mode))
@@ -2801,7 +2806,9 @@ static void VNAShell_executeLine(char *line)
     return;
   }
   shell_printf("%s?" VNA_SHELL_NEWLINE_STR, shell_args[0]);
+#ifndef VNA_SHELL_THREAD
   shell_printf(VNA_SHELL_PROMPT_STR);
+#endif
 }
 
 void shell_executeCMDLine(char *line) {


### PR DESCRIPTION
This little patch removes "ch> " prompt double printing after USB or serial command execution.

Fixes #120 