### PR TITLE
Fix warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 # Compiler options here.
 ifeq ($(USE_OPT),)
  ifeq ($(TARGET),F303)
-USE_OPT = -Og -fno-inline-small-functions -ggdb -fomit-frame-pointer -falign-functions=16 --specs=nano.specs -fstack-usage -std=c11
+USE_OPT = -Og -fno-inline-small-functions -ggdb -fomit-frame-pointer -falign-functions=16 --specs=nano.specs -fstack-usage -std=gnu11
 #USE_OPT+=-fstack-protector-strong
  else
 USE_OPT = -Og -fno-inline-small-functions -ggdb -fomit-frame-pointer -falign-functions=16 --specs=nano.specs -fstack-usage -fsingle-precision-constant 

--- a/si4468.c
+++ b/si4468.c
@@ -232,7 +232,7 @@ bool PE4302_Write_Byte(unsigned char DATA )
   if (SI4432_SPI_SPEED != PE_SPI_SPEED)
     SPI_BR_SET(SI4432_SPI, PE_SPI_SPEED);
   SPI_WRITE_8BIT(SI4432_SPI, DATA);
-  while (SPI_IS_BUSY(SI4432_SPI));
+  while (SPI_IS_BUSY(SI4432_SPI)) {};
 #else                               // Run PE4312 in SW mode to avoid disturbances
   set_SPI_mode(SPI_MODE_PE);
   software_shiftOut(DATA);
@@ -403,7 +403,7 @@ void ADF4351_Latch(void)
 {
   if (ADF4351_dirty == false)
     return;
-  while (SPI_IS_BUSY(SI4432_SPI)); // drop rx and wait tx
+  while (SPI_IS_BUSY(SI4432_SPI)) {}; // drop rx and wait tx
   CS_ADF0_HIGH;
 }
 
@@ -522,7 +522,7 @@ freq_t xtal;
 
 uint64_t ADF4351_set_frequency(int channel, uint64_t freqHz) {
   (void) channel;
-  // RFout = xtalFreqHz × (N + FRAC/MOD) = xtalFreqHz × (N * MOD + FRAC) / MOD
+  // RFout = xtalFreqHz ï¿½ (N + FRAC/MOD) = xtalFreqHz ï¿½ (N * MOD + FRAC) / MOD
   // step = xtalFreqHz / MOD; !!!! should get integer result, also this result should divided by 16
   // for 24M step = 24M / 4000 = 6k and 6k/16 = 375
   // Nx = RFout / step
@@ -1310,7 +1310,7 @@ void SI4463_do_first_api(void* data, uint8_t len, void* out, uint8_t outLen)
     while (SPI_TX_IS_NOT_EMPTY(SI4432_SPI));
     SPI_WRITE_8BIT(SI4432_SPI, *ptr++);
   }
-  while (SPI_IS_BUSY(SI4432_SPI));
+  while (SPI_IS_BUSY(SI4432_SPI)) {};
 #else
   while (len--)
     shiftOut(*ptr++); // (pgm_read_byte(&((uint8_t*)data)[i]));
@@ -1359,7 +1359,7 @@ int SI4463_do_api(void* data, uint8_t len, void* out, uint8_t outLen)
     while (SPI_TX_IS_NOT_EMPTY(SI4432_SPI));
     SPI_WRITE_8BIT(SI4432_SPI, *ptr++);
   }
-  while (SPI_IS_BUSY(SI4432_SPI));
+  while (SPI_IS_BUSY(SI4432_SPI)) {};
 #else
   while (len--)
     shiftOut(*ptr++); // (pgm_read_byte(&((uint8_t*)data)[i]));

--- a/ui.c
+++ b/ui.c
@@ -1595,7 +1595,7 @@ static const menuitem_t  menu_settings3[];
 static const menuitem_t  menu_measure_noise_figure[];
 static const menuitem_t  menu_calibrate_harmonic[];
 static const menuitem_t  menu_calibrate_normal[];
-static const menuitem_t  menu_calibrate_max[];
+// static const menuitem_t  menu_calibrate_max[];
 #endif
 static const menuitem_t  menu_calibrate[];
 static const menuitem_t  menu_sweep[];
@@ -5593,7 +5593,7 @@ static void fetch_numeric_target(uint8_t mode)
     plot_printf(uistat.text, sizeof uistat.text, "%.3QHz", uistat.freq_value);
     break;
   case KM_BAND_SPAN:
-    uistat.freq_value = abs(setting.bands[active_band].end-setting.bands[active_band].start);
+    uistat.freq_value = setting.bands[active_band].end-setting.bands[active_band].start;
     plot_printf(uistat.text, sizeof uistat.text, "%.3QHz", uistat.freq_value);
     break;
   case KM_BAND_LEVEL:
@@ -5878,7 +5878,7 @@ set_numeric_value(void)
     break;
   case KM_BAND_CENTER:
   {
-    freq_t span = abs(setting.bands[active_band].end - setting.bands[active_band].start);
+    freq_t span = setting.bands[active_band].end - setting.bands[active_band].start;
     freq_t center = uistat.freq_value - (setting.frequency_offset - FREQUENCY_SHIFT);
     setting.bands[active_band].start = center - span/2;
     setting.bands[active_band].end = center + span/2;
@@ -6396,7 +6396,7 @@ redraw_cal_status:
   // Compact status string
 //  ili9341_set_background(LCD_FG_COLOR);
   ili9341_set_foreground(LCD_FG_COLOR);
-  strncpy(buf,"      ",BLEN-1);
+  strncpy(buf,"      ",BLEN);
   if (setting.auto_IF)
     buf[0] = 'f';
   else


### PR DESCRIPTION
* Remove unused variable menu_calibrate_max.
* Remove abs() calls on unsigned ints.
* Fix strncpy length
* Set the std to use gnu extensions (required for binary constants)