### PR TITLE
Fix erasure of progress bar when it should not be visible

### DIFF
--- a/sa_core.c
+++ b/sa_core.c
@@ -5629,7 +5629,11 @@ static volatile int dummy;
     }
 //    scandirty = true;                // To show trigger happened
   }
-  if (setting.actual_sweep_time_us > ONE_SECOND_TIME /* && MODE_INPUT(setting.mode) */) {
+  if (
+#ifdef TINYSA4
+      progress_bar &&
+#endif
+      show_bar && setting.actual_sweep_time_us > ONE_SECOND_TIME /* && MODE_INPUT(setting.mode) */) {
     // ili9341_fill(OFFSETX, CHART_BOTTOM+1, WIDTH, 1, 0);     // Erase progress bar before updating actual_sweep_time
     ili9341_set_background(LCD_BG_COLOR);
     ili9341_fill(OFFSETX, CHART_BOTTOM+1, WIDTH, 1);


### PR DESCRIPTION
When long sweep completes, a black line appeared at the bottom of the screen Also, the same issue occurred even with progress bar turned off

This commit amends 3a006f5312610c29fdacd4c145d74303c793e402, erikkaashoek/tinySA#145