### PR TITLE
Make SD card icon configurable

### DIFF
--- a/flash.c
+++ b/flash.c
@@ -121,6 +121,13 @@ config_recall(void)
 
   /* duplicated saved data onto sram to be able to modify marker/trace */
   memcpy(dst, src, sizeof(config_t));
+
+#ifdef __USE_SD_CARD__
+  // Migrate from old config without sd_icon_save member
+  if (config.sd_icon_save == 0)
+    config.sd_icon_save = SDIS_DEFAULT;
+#endif // __USE_SD_CARD__
+
   return 0;
 }
 

--- a/main.c
+++ b/main.c
@@ -1237,6 +1237,9 @@ config_t config = {
   .overclock = 0,
   .hide_21MHz = false,
 #endif
+#ifdef __USE_SD_CARD__
+  .sd_icon_save = SDIS_DEFAULT,
+#endif // __USE_SD_CARD__
 };
 
 

--- a/nanovna.h
+++ b/nanovna.h
@@ -801,6 +801,18 @@ float marker_to_value(const int i);
 #define _MODE_AUTO_FILENAME    0x10
 #define _MODE_MHZ_CSV          0x20
 
+#ifdef __USE_SD_CARD__
+// SD Icon Save (SDIS) configuration
+#define SDIS_CAPTURE (1 << 0)
+#define SDIS_TRACES (1 << 1)
+// Validity mask is needed to distinguish disabled SD card icon saving
+// from the case with old config that does not have sd_icon_save member
+// (the corresponding padding byte was always equal to zero)
+#define SDIS_VALID_MASK (1 << 7)
+#define SDIS_DEFAULT (SDIS_CAPTURE | SDIS_VALID_MASK)
+#define SDIS_IS_ENABLED ((config.sd_icon_save & ~SDIS_VALID_MASK) != 0)
+#endif // __USE_SD_CARD__
+
 #pragma pack(push, 4)
 typedef struct config {
   int32_t magic;
@@ -882,6 +894,9 @@ typedef struct config {
   uint8_t hide_21MHz;
   uint8_t no_audio_agc;
 #endif
+#ifdef __USE_SD_CARD__
+  uint8_t sd_icon_save;   // enum
+#endif // __USE_SD_CARD__
   float sweep_voltage;
   float switch_offset;
   int16_t   ext_zero_level;

--- a/plot.c
+++ b/plot.c
@@ -1995,7 +1995,7 @@ static const uint8_t sd_icon [] = {
   _BMP16(0b0101010101011000),  //14
   _BMP16(0b0111111111111000)   //
   };
-  if (SD_Inserted()){
+  if (SD_Inserted() && SDIS_IS_ENABLED) {
     ili9341_set_foreground(LCD_BRIGHT_COLOR_GREEN);
     ili9341_blitBitmap(4, SD_CARD_START, 16, 16, sd_icon);
 //  ili9341_drawstring("-SD-", x, SD_CARD_START);


### PR DESCRIPTION
It's now possible to save capture, traces, or both by clicking SD card icon.
Disabling both options hides SD card icon.
Config submenu was added to Storage menu, and all settings were moved there.
Existing config remains valid, and default behavior with saving a capture is kept.