### PR TITLE
Reversed a few tight loops

### DIFF
--- a/plot.c
+++ b/plot.c
@@ -334,8 +334,8 @@ marker_to_value(const int i)
 #endif
     )
       setting.unit = U_WATT;            // Noise averaging should always be done in Watts
-    v = 0;
-    for (int i=0; i<sweep_points; i++)
+    v = value(ref_marker_levels[0])
+    for (int i=sweep_points-1; i != 0; i--) 
       v += value(ref_marker_levels[i]); // TODO this should be power averaging for noise markers
     v /= sweep_points;
     v = to_dBm(v);
@@ -1152,7 +1152,9 @@ draw_cell(int m, int n)
     c = GET_PALTETTE_COLOR(LCD_TRIGGER_COLOR);
     for (x = 0; x < w; x++)
       if (x+x0 == WIDTH/3 || x+x0 == 2*WIDTH/3 ) {
-        for (y = 0; y < h; y++) cell_buffer[y * CELLWIDTH + x] = c;
+        for (y = h-1; y != 0; y--) 
+            cell_buffer[y * CELLWIDTH + x] = c;
+        cell_buffer[CELLWIDTH + x] = c;
     }
   }
 #endif
@@ -2060,16 +2062,19 @@ int display_test_pattern(pixel_t p)
   // write and read display, return false on fail.
   for (int h = 0; h < LCD_HEIGHT; h++) {
     // write test pattern to LCD
-    for (int w = 0; w < LCD_WIDTH; w++)
+    for (int w = LCD_WIDTH-1; w != 0; w--)
       spi_buffer[w] = p;
+    spi_buffer[0] = p;
     ili9341_bulk(0, h, LCD_WIDTH, 1);
     // Cleanup buffer
     memset(spi_buffer, 0, LCD_WIDTH * sizeof(pixel_t));
     // try read data
     ili9341_read_memory(0, h, LCD_WIDTH, 1, spi_buffer);
     // Check pattern from data    for (volatile int w = 0; w < LCD_WIDTH; w++)
-    for (int w = 0; w < LCD_WIDTH; w++)
+    for (int w = LCD_WIDTH-1; w != 0; w--)
       if (spi_buffer[w] != p)
+        return false;
+    if (spi_buffer[0] != p) 
         return false;
   }
   return true;


### PR DESCRIPTION
An old optimization trick: Remove the comparison from the loop.

For example:
```
int b=1000; // some dynamic large number
for (int i=0; i<b; i++)
  // do something[i]...
```
The comparison `i<b` will be done a thousand times.
In assembly it would look like:
```
LDA i // load i into register A
LDB b // load b into register B
CMP A B // compare registers A and B
JNE ... // Jump non equal
```

Replace that code with:
```
int b=1000; // some dynamic large number
for (int i=b-1; i!=0; i--)
  // do something[i]...
// do something[0]...
```

In assemby the `i!=0` comparison looks like
```
LDA i // load i into register A
JNZ ... // Jump non zero
```

Which (depending on the compiler, processor and branch prediction) usually results in a faster loop.
Note that the loop does not include zero, so the [0] item will have to be done separately.

Disclaimer: I could not compile, or test these changes, still figuring out how to set this up, I just applied the technique to some random places hoping I would hit a significant one :-)

It is not always worthwhile. Small static loops would be unwind-ed by the compiler. If the stuff inside the loop is extensive then the difference would be insignificant. It usually helps with copying buffers or things like moving the waterfall one pixel down (could not find that part though).

Hope this helps a little, even if it only extends battery life when the processor is not a bottleneck.